### PR TITLE
chore: set up Cloud Agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,27 @@ Some existing code may still violate this governance baseline. When touching leg
 - If full cleanup is too large, isolate the change and leave the next seam explicit in docs or tests.
 
 The goal is not abstract purity. The goal is a system where model intent, local execution, user authorization, and factual Evidence stay separate and traceable.
+
+## Cursor Cloud specific instructions
+
+This section captures non-obvious environment/runtime caveats for Cloud Agents. Standard commands live in `README.md` and the `scripts` of the root/`apps/*` `package.json`; this section only adds what is not obvious there. The startup update script only runs `pnpm install --frozen-lockfile`; everything else below is already baked into the VM snapshot or must be run on demand.
+
+### Toolchains (already provisioned in the snapshot)
+
+- Node: use the nvm-managed Node (currently v22.23.2), not the `/exec-daemon/node` (v22.14) that is first on the raw `PATH`. `~/.bashrc` prepends the nvm `node`/`pnpm` (corepack) so a login/interactive shell resolves the right one. Node must be `>= 22.18` because several packages run TypeScript test files directly via `node --test src/*.test.ts` (native type stripping); the exec-daemon Node 22.14 fails these with `ERR_UNKNOWN_FILE_EXTENSION`.
+- `pnpm` (10.22.0, pinned by `packageManager`) is provided through corepack on the nvm Node.
+- Bun is installed (`~/.bun/bin`, on `PATH` via `~/.bashrc`) and is required by `apps/tui` (`pnpm --filter @peer-agent/tui dev|build|test`).
+- Rust: the default toolchain is stable `>= 1.85` (the `peer-credential-helper` crate is `edition = "2024"`). The system lib `libdbus-1-dev` (+ `pkg-config`) is installed because the Linux `keyring`/`dbus-secret-service` crate needs it to compile.
+
+### Building and testing
+
+- Automated tests import each workspace package's built `dist/`, so run a build before `pnpm test` (e.g. `pnpm build`, or the per-package `pnpm --filter <pkg> build` chain). A clean checkout without `dist/` fails tests with `ERR_MODULE_NOT_FOUND` for `@peer-agent/*`.
+- `pnpm test` runs every package's tests in parallel (`pnpm -r`). Timing-sensitive desktop tests (fake timers / readiness timeouts) can flake as `cancelledByParent` ("Promise resolution is still pending…") under that load. Re-run the single file/package in isolation (`node --test <file>`) to get a stable result.
+- Known pre-existing failures on `main` (NOT caused by the environment — do not chase them during setup): 5 desktop tests fail deterministically (`full-disk-access-drag-float`, `goal-plan-store` ×2, `qoder-private-adapter`, `task-overview-aggregator`); `pnpm typecheck` reports one error in `packages/protocol/src/goal.test.ts`; `pnpm architecture:check` reports 2 local `@keyframes` CSS violations.
+
+### Running the apps
+
+- Desktop (primary product): `pnpm dev` (root) → builds the runtime packages + credential helper, then runs Vite (`127.0.0.1:5173`) + Electron. It needs a display: `export DISPLAY=:1` (the same X server used by computer-use). The `dbus/bus.cc … Failed to connect to the bus` and `GpuControl.CreateCommandBuffer` errors in the logs are benign in this headless container.
+- The credential vault relies on the OS Secret Service / keychain, which is unavailable headless. Adding an API-key provider in the UI fails with a credential-store error. For UI flows that need a configured model channel, use the "Qoder (本机 CLI)" local provider, which does not persist a secret.
+- App data lives in `~/.peer-agent`. Remove or rename that directory to reset the app to first-run onboarding (0 channels · 0 models).
+- TUI/CLI: `apps/tui/dist/peer` is the compiled binary (`peer --version`); `pnpm --filter @peer-agent/tui dev` runs it from source via Bun.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the Peer Agent development environment for Cloud Agents. No product code was changed — the only tracked change is documenting durable, non-obvious setup caveats in `AGENTS.md`.

## Environment setup

- Update script (runs on VM startup): `pnpm install --frozen-lockfile`
- Snapshot-baked toolchains: nvm Node `v22.23.2` (made default over the exec-daemon Node 22.14 via `~/.bashrc`, needed for `node --test` native TS stripping), Bun (for `apps/tui`), Rust stable `>= 1.85` (crate is `edition 2024`), and the system lib `libdbus-1-dev` + `pkg-config` (required to compile the Linux `keyring`/`dbus-secret-service` crate).

## Verified

| Service | Lint / Typecheck | Test | Build | Run |
| --- | --- | --- | --- | --- |
| Desktop (`apps/desktop`, Electron) | `pnpm architecture:check`, `pnpm typecheck` | `pnpm --filter @peer-agent/desktop test` (2557 pass) | `pnpm build` | `pnpm dev` on `DISPLAY=:1` |
| TUI/CLI (`apps/tui`) | `pnpm typecheck` | package tests via Bun | `pnpm --filter @peer-agent/tui build` | `apps/tui/dist/peer --version` |
| Runtime/protocol packages | `pnpm typecheck` | `pnpm test` (all green) | `pnpm build` | — |

Hello-world: launched the Desktop app and completed the documented first-user onboarding action — adding a model provider — taking the Providers page from `0 channels · 0 models` to `1 channels · 1 models`.

## Pre-existing issues (not caused by setup; source matches `origin/main`)

- 5 deterministic desktop test failures (`full-disk-access-drag-float`, `goal-plan-store` ×2, `qoder-private-adapter`, `task-overview-aggregator`).
- One `pnpm typecheck` error in `packages/protocol/src/goal.test.ts`.
- Two `pnpm architecture:check` CSS `@keyframes` violations.

These are documented in `AGENTS.md` so future agents don't chase them.

[peer_agent_desktop_add_provider_hello_world.mp4](https://cursor.com/agents/bc-0ade4ecc-c92e-486c-b0dd-eb0a8ea692b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpeer_agent_desktop_add_provider_hello_world.mp4)

[Providers page showing 1 channel and 1 model](https://cursor.com/agents/bc-0ade4ecc-c92e-486c-b0dd-eb0a8ea692b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpeer_agent_providers_1_channel.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ade4ecc-c92e-486c-b0dd-eb0a8ea692b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ade4ecc-c92e-486c-b0dd-eb0a8ea692b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

