### PR TITLE
fix(release): refresh lockfile for v0.0.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         specifier: ^11.11.1
         version: 11.11.1
       playwright-core:
-        specifier: ^1.62.1
+        specifier: ^1.55.0
         version: 1.62.1
       react:
         specifier: ^19.2.0
@@ -1037,6 +1037,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}


### PR DESCRIPTION
## Summary
Fix the v0.0.11 build failure: `package.json` declares `playwright-core ^1.55.0` while `pnpm-lock.yaml` recorded `^1.62.1`, so every CI job failed at `pnpm install --frozen-lockfile` (`ERR_PNPM_OUTDATED_LOCKFILE`).

- Recompute the lockfile from the manifest (specifier now `^1.55.0`, resolves to 1.62.1)
- Verified locally: `pnpm install --frozen-lockfile` passes

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally
- After merge: delete and re-create tag `v0.0.11` to re-trigger `release.yml`