### PR TITLE
fix(goal): 升级 intake→accepted_goal 时原子消费陈旧中断，防止 Runner 永不启动

### DIFF
--- a/apps/desktop/electron/main/goal-plan-store.test.mjs
+++ b/apps/desktop/electron/main/goal-plan-store.test.mjs
@@ -2075,6 +2075,59 @@ test('upsertGoalContract: 只在 intake 升级时发出 goal-accepted，Runner �
   assert.equal(events.at(-1)?.changeKind, 'persist');
 });
 
+test('upsertGoalContract: 升级消费陈旧 stream 中断，goal-accepted 后 Runner 闸门放行（回归：turnCount=0 停摆）', () => {
+  // 复刻事故现场（plan 464f9554）：
+  // 1. goal 首答建立 intake 契约；2. 普通回合流错误写入 recoverable:false 中断，
+  //    persist 的 hasUnconsumedInterruption 不变量把契约派生为 failed；
+  // 3. 用户续聊后模型调用 goal_create_plan 升级 intake → accepted_goal。
+  // 修复前：升级写入被不变量压回 failed → auto-start 闸门拒绝 → Runner 永不启动。
+  // 修复后：升级是全新的目标接受决策，陈旧中断被原子消费，闸门按 accepted 放行。
+  const intake = store.createIntakeContract({
+    conversationId: 'conv-stale-interruption',
+    goal: '修复权限判断并部署预发',
+  });
+  store.setRunnerState(intake.planId, {
+    enabled: true,
+    status: 'failed',
+    phase: 'blocked',
+    interruption: {
+      source: 'stream_interrupted',
+      reason: 'error',
+      recoverable: false,
+      attempt: 1,
+      interruptedAt: '2026-09-03T02:19:52.080Z',
+    },
+  });
+  const poisoned = store.getPlan(intake.planId);
+  assert.equal(poisoned.status, 'failed', '中断写入后契约被毒化为 failed（事故现场）');
+  assert.equal(poisoned.runner.interruption.source, 'stream_interrupted');
+
+  const upgraded = store.upsertGoalContract('conv-stale-interruption', {
+    goal: '修复 nexus 权限判断并部署预发',
+    title: '修复 nexus 权限判断并部署预发',
+    status: 'accepted',
+    activation: { kind: 'accepted_goal' },
+    tasks: [
+      { taskId: 'read-deps', title: '读取依赖', status: 'pending', evidenceRefs: [] },
+      { taskId: 'fix-acl', title: '修复 ACL', status: 'pending', evidenceRefs: [] },
+      { taskId: 'deploy', title: '部署预发', status: 'pending', evidenceRefs: [] },
+    ],
+  });
+
+  assert.equal(upgraded.planId, intake.planId, '必须原地升级，planId 不变');
+  assert.equal(upgraded.status, 'accepted', '升级后 status 必须是 accepted，不得被陈旧中断毒化为 failed');
+  assert.equal(upgraded.activation?.kind, 'accepted_goal');
+  assert.equal(upgraded.runner?.interruption, undefined, '陈旧中断必须被原子消费');
+  assert.equal(upgraded.runner?.enabled, true, 'runner 必须重新武装');
+  assert.equal(upgraded.runner?.status, 'running', 'runner 必须处于可被 auto-start 接管的形态');
+
+  // 后续普通 persist 不再被陈旧中断毒化（中断已消费）。
+  store.setPlanStatus(upgraded.planId, 'executing');
+  const afterPersist = store.getPlan(upgraded.planId);
+  assert.equal(afterPersist.status, 'executing', '中断消费后普通 persist 不得再派生 failed');
+  assert.equal(afterPersist.runner?.interruption, undefined);
+});
+
 test('派生子目标会反向关联父任务并联动执行状态', () => {
   const parent = store.createPlan({
     conversationId: 'conv-parent-link',

--- a/packages/runtime-node/src/goal-plan-store.mjs
+++ b/packages/runtime-node/src/goal-plan-store.mjs
@@ -2816,12 +2816,35 @@ export function createGoalPlanStore({
     const upgradingFromIntake = activeGoal.activation?.kind === 'intake'
       && (planPatch.activation?.kind === 'accepted_goal' || requestedStatus === 'accepted');
     const shouldEmitGoalAccepted = upgradingFromIntake;
+    // normalizeRunnerState 会保留合法的 interruption 事实；这里取规范化后的 runner
+    // 快照用于升级路径（若契约无 runner 则视为无陈旧中断可消费）。
+    const upgradingFromIntakeRunner = upgradingFromIntake
+      ? normalizeRunnerState(activeGoal.runner, activeGoal.planId)
+      : null;
+    // 升级 intake → accepted_goal 是一次全新的目标接受决策。intake 期间写入的
+    // stream 中断事实（recoverable:false）属于已被取代的前一回合，不得毒化这次
+    // 升级：persist() 的 hasUnconsumedInterruption 不变量会把契约压回 failed，
+    // auto-start 闸门随即拒绝启动 Runner（turnCount=0 永久停摆）。在此原子消费
+    // 该中断并重新武装 runner，使 goal-accepted 事件后的启动闸门按 accepted 放行。
+    const staleInterruption = upgradingFromIntakeRunner?.interruption ?? null;
+    const consumedInterruptionPatch = staleInterruption
+      ? {
+        runner: {
+          ...upgradingFromIntakeRunner,
+          enabled: true,
+          status: 'running',
+          interruption: undefined,
+          updatedAt: new Date().toISOString(),
+        },
+      }
+      : null;
     return revisePlan(activeGoal.planId, {
       ...planPatch,
       conversationId: normalizedConversationId ?? activeGoal.conversationId,
       tasks,
       status: safeStatus,
       workflowKind: 'goal_self_driven',
+      ...(consumedInterruptionPatch || {}),
       activation: {
         ...(activeGoal.activation || {}),
         ...(planPatch.activation || {}),


### PR DESCRIPTION
事故现场（plan 464f9554）：goal 首答建立 intake 契约后，普通回合的流错误在 runner 上留下 recoverable:false 的 stream_interrupted 中断；此后模型调用 goal_create_plan 把契约升级为 accepted_goal 时，persist() 的 hasUnconsumedInterruption 不变量把升级写入强制派生为 failed，覆盖调用方 传入的 accepted。goal-accepted 事件后 shouldAutoStartAcceptedGoalRunner 因 status!=='accepted' 拒绝启动 Runner，而当前回合已按 goal_handoff 终止， turnCount=0 永久停摆（界面卡 0/N）。

根因：intake 期间写入的中断事实属于已被取代的前一回合；一次全新的目标
接受决策（goal_create_plan 升级）不应被陈旧中断毒化。仅 resumeRunner 能 原子消费该事实的规则对用户显式恢复成立，但升级路径漏掉了同样的消费。

修复：upsertGoalContract 检测 upgradingFromIntake 且存在未消费中断时， 在同一次 revisePlan 写入中原子消费——清 interruption、把 runner 重新 武装为 enabled/running（对齐事故现场 11:35 的重新武装形态），使
goal-accepted 事件后的 auto-start 闸门按 accepted 放行。

回归测试复刻事故现场：intake + 未消费 recoverable:false 中断 →
upsertGoalContract 升级 → 断言 accepted、中断被消费、runner 重武装、 后续普通 persist 不再毒化。