### PR TITLE
feat(desktop): Linux x64 AppImage / .deb 正式打包轨道

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,15 @@
 #
 # 链路（拆分 build / publish，消除并行发布竞态）：
 #   meta      → 从 tag 解析版本 / 通道 / releaseType / prerelease（单一事实源）
-#   build     → matrix（mac + win）各自构建 Desktop，electron-builder --publish never
-#               只产出安装包与更新清单（*-mac.yml / *.yml），不直接发布，
+#   build     → matrix（mac + win + linux）各自构建 Desktop，electron-builder --publish never
+#               只产出安装包与更新清单（*-mac.yml / *.yml / *-linux.yml），不直接发布，
 #               产物经 upload-artifact 上传。
 #   build-cli → 构建 CLI 归档（peer + peer-credential-helper 同目录），
 #               当前矩阵：darwin-arm64（macos-14）+ linux-x64（ubuntu-latest）。
 #               关键失败阻断整个 Release。
 #   release   → 单个 job 下载 Desktop + CLI 产物，一次性创建/更新同一个 GitHub Release。
 #
-# 为什么拆分：mac、win 两个 matrix job 若各自 --publish 到同一 tag，会并发
+# 为什么拆分：mac、win、linux 三个 matrix job 若各自 --publish 到同一 tag，会并发
 #   抢建 Release，导致同一 tag 出现多个 Release、产物被劈开（electron-builder
 #   + Actions matrix 的已知竞态）。集中到单个 release job 发布可彻底消除。
 #
@@ -102,6 +102,9 @@ jobs:
           - os: windows-latest
             platform: win
             ebflags: --win
+          - os: ubuntu-latest
+            platform: linux
+            ebflags: --linux --x64
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -135,6 +138,12 @@ jobs:
         shell: bash
         run: node scripts/stamp-version.mjs "${{ needs.meta.outputs.version }}"
 
+      - name: Install Linux desktop build deps
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config fakeroot dpkg
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -142,6 +151,7 @@ jobs:
       # 从 target/release/ 拷贝 peer-credential-helper。
       # 注意（阶段一）：Windows arm64 安装包将打包 x64 native binaries（在 win-arm64
       # 上以模拟方式运行）；arm64-native 交叉编译留待阶段二。
+      # Linux Desktop 阶段一仅 x64；linux-arm64 Desktop 留待后续。
       - name: Build Rust native binaries
         run: cargo build --locked --release --package peer-credential-helper
 
@@ -149,7 +159,8 @@ jobs:
         run: pnpm --filter @peer-agent/desktop build
 
       # 只构建、不发布（--publish never）。electron-builder 仍会按通道语义生成
-      # 更新清单（beta-mac.yml / beta.yml 或 latest-mac.yml / latest.yml）。
+      # 更新清单（beta-mac.yml / beta.yml / beta-linux.yml 或
+      # latest-mac.yml / latest.yml / latest-linux.yml）。
       - name: Build (electron-builder, no publish)
         working-directory: apps/desktop
         shell: bash
@@ -173,6 +184,8 @@ jobs:
             dist-electron/*.dmg
             dist-electron/*.zip
             dist-electron/*.exe
+            dist-electron/*.AppImage
+            dist-electron/*.deb
             dist-electron/*.blockmap
             dist-electron/*.yml
           if-no-files-found: error
@@ -306,6 +319,13 @@ jobs:
           # CLI 归档必须在 Release 资产中（当前：darwin-arm64 + linux-x64）
           test -f release-assets/peer-darwin-arm64.tar.gz
           test -f release-assets/peer-linux-x64.tar.gz
+          # Desktop Linux 一等产物：AppImage + .deb + 更新清单
+          shopt -s nullglob
+          linux_appimages=(release-assets/*.AppImage)
+          linux_debs=(release-assets/*.deb)
+          test "${#linux_appimages[@]}" -ge 1
+          test "${#linux_debs[@]}" -ge 1
+          test -f release-assets/latest-linux.yml -o -f release-assets/beta-linux.yml
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Peer Agent are tracked here.
 
 ## Unreleased
 
+### Notes
+
+- Linux Desktop x64 is now a first-class GitHub Release asset (`Peer-Agent-<ver>-x64.AppImage` / `.deb`) with updater channel files (`latest-linux.yml` / `beta-linux.yml`). Builds are unsigned in stage-1 (same posture as mac ad-hoc). linux-arm64 Desktop and Linux code signing remain follow-ups. The CLI archive matrix is unchanged.
+
 ## [0.0.11] - 2026-09-02
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -189,9 +189,18 @@ It doesn't matter where work enters — config, permissions, and Evidence are al
 ### Option A — Desktop (recommended for most users)
 
 1. Download a release from **[GitHub Releases](https://github.com/ly-ccx/Peer-Agent/releases)**
+
+   | Platform | First-class artifact | Notes |
+   | --- | --- | --- |
+   | macOS arm64 | `Peer-Agent-<ver>-arm64.dmg` | Stage-1 ad-hoc signed |
+   | Windows x64 / arm64 | `Peer-Agent-Setup-<ver>.exe` | |
+   | Linux x64 | `Peer-Agent-<ver>-x64.AppImage` (preferred) or `.deb` | Unsigned (stage-1). In-app auto-update is AppImage-only (`latest-linux.yml` / `beta-linux.yml`). Ubuntu 22+/24+ AppImage users may need `libfuse2`. linux-arm64 Desktop is not a Release asset yet. |
+
 2. Install and open Peer Agent
 3. Add a model provider / API key in settings
 4. Start a conversation — or hand it a real goal and let **Agent** mode drive
+
+On Linux Wayland, if the window fails to appear, try X11 or `ELECTRON_OZONE_PLATFORM_HINT=auto`.
 
 ### Option B — CLI / TUI via npm
 
@@ -215,6 +224,12 @@ pnpm install
 
 # Desktop (Electron)
 pnpm --filter @peer-agent/desktop dev
+
+# Linux Desktop unpacked dir (sandbox / smoke)
+pnpm pack:linux
+
+# Linux Desktop distributables (AppImage + .deb; needs libdbus-1-dev, fakeroot, dpkg)
+pnpm dist:linux
 
 # Terminal agent (TUI)
 pnpm --filter @peer-agent/tui dev
@@ -301,7 +316,7 @@ The long-term product spine:
 
 | Pillar | Meaning |
 | --- | --- |
-| **Cross-platform** | Same product truth on macOS first, then broader desktop / environment coverage without forking the core model. |
+| **Cross-platform** | Same product truth on macOS, Windows, and Linux Desktop x64 today, then broader coverage (arm64 Desktop, signing) without forking the core model. |
 | **Unified core flow** | Desktop, TUI, CLI, Automation, MCP, plugins, and skills share one runtime chain: projection → permission → execution → Evidence. |
 | **Task flow** | Work is accepted, clarified, planned, executed, and closed as a governed task — not freelanced chat. |
 | **Self-closed loop** | Explore → plan → act → verify → adjust, with success criteria and Evidence as the completion gate. |
@@ -336,7 +351,7 @@ Philosophy stays fixed while the surface grows: **cognition is pluggable; author
 | Area | Status |
 | --- | --- |
 | Broader marketplace ecosystem | 🚧 Growing |
-| Cross-platform hardening / packaging | 🚧 Ongoing |
+| Cross-platform hardening / packaging | 🚧 Ongoing — Linux Desktop x64 (AppImage / `.deb`) is first-class; linux-arm64 Desktop and Linux signing remain follow-ups |
 
 ### Planned — not implemented yet
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,9 +189,18 @@ Capability Provider → Manifest → Runtime Projection → Tool Call → Permis
 ### 方式 A —— Desktop（大多数用户推荐）
 
 1. 从 **[GitHub Releases](https://github.com/ly-ccx/Peer-Agent/releases)** 下载发行包
+
+   | 平台 | 一等产物 | 说明 |
+   | --- | --- | --- |
+   | macOS arm64 | `Peer-Agent-<ver>-arm64.dmg` | 阶段一 ad-hoc 签名 |
+   | Windows x64 / arm64 | `Peer-Agent-Setup-<ver>.exe` | |
+   | Linux x64 | `Peer-Agent-<ver>-x64.AppImage`（推荐便携）或 `.deb` | 阶段一未签名。应用内自动更新只支持 AppImage（`latest-linux.yml` / `beta-linux.yml`）。Ubuntu 22+/24+ 跑 AppImage 可能需要 `libfuse2`。linux-arm64 Desktop 尚未作为 Release 资产。 |
+
 2. 安装并打开 Peer Agent
 3. 在设置中添加模型服务商 / API Key
 4. 开始对话 —— 或直接给它一个真实目标，让 **Agent** 模式推进
+
+Linux Wayland 下如果窗口起不来，可改用 X11 或设置 `ELECTRON_OZONE_PLATFORM_HINT=auto`。
 
 ### 方式 B —— 通过 npm 安装 CLI / TUI
 
@@ -215,6 +224,12 @@ pnpm install
 
 # Desktop（Electron）
 pnpm --filter @peer-agent/desktop dev
+
+# Linux Desktop unpacked dir（沙箱 / 冒烟）
+pnpm pack:linux
+
+# Linux Desktop 发行包（AppImage + .deb；需要 libdbus-1-dev、fakeroot、dpkg）
+pnpm dist:linux
 
 # 终端 Agent（TUI）
 pnpm --filter @peer-agent/tui dev
@@ -301,7 +316,7 @@ Peer Agent 的目标是成为面向真实工作的 **跨平台 Agent 操作系�
 
 | 支柱 | 含义 |
 | --- | --- |
-| **跨平台** | 以 macOS 为先，再扩展更广的桌面 / 运行环境，不分裂核心模型。 |
+| **跨平台** | 今天已覆盖 macOS、Windows 与 Linux Desktop x64，再扩展（arm64 Desktop、签名）时不分裂核心模型。 |
 | **统一核心流** | Desktop、TUI、CLI、Automation、MCP、插件与技能共享同一条运行时链：投影 → 授权 → 执行 → Evidence。 |
 | **任务流转** | 工作以受治理任务被签收、澄清、规划、执行与关闭 —— 而不是闲聊式乱做。 |
 | **自我闭环** | 探索 → 规划 → 行动 → 验证 → 调整，以成功标准与 Evidence 作为完成闸门。 |
@@ -336,7 +351,7 @@ Peer Agent 的目标是成为面向真实工作的 **跨平台 Agent 操作系�
 | 领域 | 状态 |
 | --- | --- |
 | 更广泛的 marketplace 生态 | 🚧 建设中 |
-| 跨平台加固 / 打包 | 🚧 持续推进 |
+| 跨平台加固 / 打包 | 🚧 持续推进 —— Linux Desktop x64（AppImage / `.deb`）已是一等产物；linux-arm64 Desktop 与 Linux 签名仍待后续 |
 
 ### 规划中 —— 尚未实现
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -105,8 +105,12 @@ linux:
   category: Development
   executableName: peer-agent
   synopsis: Local-first Task Flow Agent
+  # Linux ${arch} 默认是 x86_64 / amd64；阶段一只出 x64，文件名与 mac/win 的 x64 约定对齐。
+  syncDesktopName: true
   desktop:
-    StartupWMClass: peer-agent
+    entry:
+      Name: Peer Agent
+      StartupWMClass: com.peeragent.desktop
   target:
     - target: AppImage
       arch: [x64]
@@ -114,10 +118,10 @@ linux:
       arch: [x64]
 
 appImage:
-  artifactName: Peer-Agent-${version}-${arch}.${ext}
+  artifactName: Peer-Agent-${version}-x64.${ext}
 
 deb:
-  artifactName: Peer-Agent-${version}-${arch}.${ext}
+  artifactName: Peer-Agent-${version}-x64.${ext}
 
 # ── 发布 (GitHub Releases) ──
 # 通道分流由 tag 名驱动（见 .github/workflows/release.yml）：

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -96,19 +96,33 @@ nsis:
   # nsis 安装包为多架构合成的单一产物，不带 ${arch}（否则模板里 arch 为空会留下多余连字符）。
   artifactName: Peer-Agent-Setup-${version}.${ext}
 
-# ── Linux（沙箱 / CI 用 unpacked dir；正式分发可再加 AppImage）──
+# ── Linux Desktop（正式分发）──
+# 阶段一产物：AppImage x64（便携 + electron-updater 通道）与 .deb x64（apt 便利）。
+# 二者均未签名，与 mac 阶段一 ad-hoc 同级。linux-arm64 / 代码签名留待后续。
+# 沙箱 / 本地 unpacked 仍走 `pnpm pack:linux`（显式 --linux dir），不作为 Release 资产。
 linux:
   icon: build/icon.png
   category: Development
   executableName: peer-agent
+  synopsis: Local-first Task Flow Agent
+  desktop:
+    StartupWMClass: peer-agent
   target:
-    - target: dir
+    - target: AppImage
       arch: [x64]
+    - target: deb
+      arch: [x64]
+
+appImage:
+  artifactName: Peer-Agent-${version}-${arch}.${ext}
+
+deb:
+  artifactName: Peer-Agent-${version}-${arch}.${ext}
 
 # ── 发布 (GitHub Releases) ──
 # 通道分流由 tag 名驱动（见 .github/workflows/release.yml）：
-#   - 纯 vX.Y.Z         → 正式 Release（latest 通道，latest-mac.yml / latest.yml）
-#   - vX.Y.Z-beta.N     → 预发布 Release（beta 通道，beta-mac.yml / beta.yml）
+#   - 纯 vX.Y.Z         → 正式 Release（latest 通道，latest-mac.yml / latest.yml / latest-linux.yml）
+#   - vX.Y.Z-beta.N     → 预发布 Release（beta 通道，beta-mac.yml / beta.yml / beta-linux.yml）
 # generateUpdatesFilesForAllChannels 确保即使一次构建也按版本号语义写入对应通道清单。
 publish:
   provider: github

--- a/apps/desktop/electron/main/auto-updater.mjs
+++ b/apps/desktop/electron/main/auto-updater.mjs
@@ -343,6 +343,8 @@ export async function downloadUpdate() {
   }
   // mac 走自管下载链路：应用为 ad-hoc 签名，Squirrel 的「下载→签名校验→原子替换」
   // 会在校验步骤失败（code requirement 不满足）。改为自管下载 dmg + 手动打开。
+  // Windows NSIS 与 Linux AppImage 走 electron-updater 默认链路
+  // （latest.yml / latest-linux.yml）。.deb 安装不走应用内自动更新。
   if (process.platform === 'darwin') {
     return downloadUpdateMacManual();
   }

--- a/apps/desktop/electron/main/auto-updater.test.mjs
+++ b/apps/desktop/electron/main/auto-updater.test.mjs
@@ -189,11 +189,15 @@ describe('auto-updater phase-locking integration contract', () => {
     assert.match(macBlock, /state\.stallWatchdog\?\.notifyProgress\(\);/);
     assert.match(macBlock, /\} finally \{\s*\n\s*stopStallWatchdog\(\);/);
 
-    // Windows 路径同样受看门狗保护。
+    // Windows / Linux AppImage 共用 electron-updater 默认下载路径，同样受看门狗保护。
     const winIdx = source.indexOf('export async function downloadUpdate()');
     const winBlock = source.slice(winIdx, macIdx);
     assert.match(winBlock, /startDownloadStallWatchdog\(\);/);
     assert.match(winBlock, /\} finally \{\s*\n\s*stopStallWatchdog\(\);/);
+    assert.match(winBlock, /if \(process\.platform === 'darwin'\)/);
+    assert.match(winBlock, /autoUpdater\.downloadUpdate\(\)/);
+    assert.doesNotMatch(winBlock, /process\.platform === 'win32'/);
+    assert.doesNotMatch(winBlock, /process\.platform === 'linux'/);
 
     // 看门狗触发时置 error 并提供 Release 页面兜底（睡眠断流的恢复路径）。
     const stallFnIdx = source.indexOf('function startDownloadStallWatchdog()');

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
     "dist": "pnpm --dir ../.. marketplace:build && node ../../scripts/build-credential-helper.mjs --profile release && electron-builder && pnpm verify:packaged",
     "dist:mac": "pnpm --dir ../.. marketplace:build && node ../../scripts/build-credential-helper.mjs --profile release && electron-builder --mac && pnpm verify:packaged",
     "dist:win": "pnpm --dir ../.. marketplace:build && node ../../scripts/build-credential-helper.mjs --profile release && electron-builder --win && pnpm verify:packaged",
+    "dist:linux": "pnpm --dir ../.. marketplace:build && node ../../scripts/build-credential-helper.mjs --profile release && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --linux --x64 && pnpm verify:packaged",
     "verify:packaged": "node scripts/verify-packaged-runtime.cjs",
     "publish:stable": "bash scripts/publish.sh stable",
     "publish:beta": "bash scripts/publish.sh beta",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.11",
   "description": "Peer Agent Desktop - local-first Task Flow Agent",
   "author": "Peer Agent Team <dev@peer-agent.local>",
+  "homepage": "https://github.com/ly-ccx/Peer-Agent",
+  "desktopName": "com.peeragent.desktop",
   "private": true,
   "type": "module",
   "main": "electron/main/main.mjs",
@@ -65,5 +67,8 @@
     "typescript": "^5.9.3",
     "wait-on": "^9.0.3"
   },
-  "repository": ""
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ly-ccx/Peer-Agent.git"
+  }
 }

--- a/apps/desktop/renderer/src/app/components/VersionBadge.tsx
+++ b/apps/desktop/renderer/src/app/components/VersionBadge.tsx
@@ -67,7 +67,8 @@ export function VersionBadge({ i18n }: { readonly i18n: I18nRuntime }) {
     }
   };
 
-  // 完成态安装按钮的 label：Windows = 重启安装；mac = 安装。
+  // 完成态安装按钮的 label：ready-to-open（mac 自管 dmg）= 打开安装包；
+  // downloaded（Windows NSIS / Linux AppImage）= 重启安装。
   const installLabel =
     phase === 'ready-to-open'
       ? i18n.t('updater.badge.openInstaller')

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -429,7 +429,7 @@
                 <tr>
                   <td><strong>Desktop</strong></td>
                   <td data-i18n="welcome.desktopUse">Visual Thread / Workbench / Evidence review</td>
-                  <td data-i18n="welcome.desktopNotes">Electron shell; macOS + Windows via Releases</td>
+                  <td data-i18n="welcome.desktopNotes">Electron shell; macOS, Windows, and Linux x64 via Releases</td>
                 </tr>
                 <tr>
                   <td><strong>CLI · <code>peer</code></strong></td>
@@ -492,8 +492,18 @@
                   <td>installer / package on Releases</td>
                   <td data-i18n="install.winHow">Download → run installer → launch Peer Agent</td>
                 </tr>
+                <tr>
+                  <td>Linux x64</td>
+                  <td><code>Peer-Agent-&lt;ver&gt;-x64.AppImage</code> / <code>.deb</code></td>
+                  <td data-i18n="install.linuxHow">Download AppImage, <code>chmod +x</code>, run — or install the <code>.deb</code>. In-app auto-update is AppImage-only.</td>
+                </tr>
               </tbody>
             </table>
+          </div>
+          <div class="callout" data-i18n="install.linuxGaps">
+            <strong>Linux Desktop gaps (stage-1):</strong> x64 only, unsigned (same stage-1 posture as mac ad-hoc).
+            Ubuntu 22+/24+ AppImage users may need <code>libfuse2</code>. On Wayland, if the window fails to appear, try X11 or
+            <code>ELECTRON_OZONE_PLATFORM_HINT=auto</code>. linux-arm64 Desktop is a follow-up.
           </div>
           <div class="inline-actions">
             <a class="btn btn-primary" href="https://github.com/ly-ccx/Peer-Agent/releases" target="_blank" rel="noreferrer">GitHub Releases</a>
@@ -562,6 +572,12 @@ pnpm install
 
 # Desktop
 pnpm --filter @peer-agent/desktop dev
+
+# Linux Desktop unpacked dir (sandbox / smoke)
+pnpm pack:linux
+
+# Linux Desktop distributables (AppImage + .deb)
+pnpm dist:linux
 
 # TUI source package lives at apps/tui (@peer-agent/tui)
 # Public npm installer package is packages/npm-cli (@peer-agent/cli)</code></pre>
@@ -1382,7 +1398,7 @@ Evidence owns governance.</code></pre>
             "welcome.entriesTitle": "工作从哪里进来",
             "welcome.thEntry": "入口", "welcome.thUse": "适合", "welcome.thNotes": "说明",
             "welcome.desktopUse": "可视化 Thread / Workbench / Evidence 审查",
-            "welcome.desktopNotes": "Electron 壳；macOS + Windows 走 Releases",
+            "welcome.desktopNotes": "Electron 壳；macOS、Windows、Linux x64 走 Releases",
             "welcome.cliUse": "终端 / headless 会话",
             "welcome.cliNotes": "不必装 Desktop；共享 ~/.peer-agent",
             "welcome.canTitle": "今天能做什么",
@@ -1406,6 +1422,8 @@ Evidence owns governance.</code></pre>
             "install.thPlat": "平台", "install.thArtifact": "典型产物", "install.thHow": "步骤",
             "install.macHow": "下载 → 打开 → 安装到应用程序",
             "install.winHow": "下载 → 运行安装器 → 启动 Peer Agent",
+            "install.linuxHow": "下载 AppImage 后 chmod +x 再运行，或安装 .deb。应用内自动更新只支持 AppImage。",
+            "install.linuxGaps": "Linux Desktop 阶段一缺口：仅 x64、未签名（与 mac 阶段一 ad-hoc 同级）。Ubuntu 22+/24+ 跑 AppImage 可能需要 libfuse2。Wayland 下窗口起不来时改用 X11 或 ELECTRON_OZONE_PLATFORM_HINT=auto。linux-arm64 Desktop 仍待后续。",
             "install.changelog": "更新日志",
             "install.cliTitle": "仅 CLI（@peer-agent/cli）",
             "install.cliBody": "公开安装包名：@peer-agent/cli。它是薄安装器——postinstall 会从匹配的 GitHub Release tag 下载平台二进制，然后 peer bin 启动 vendor 二进制。",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1091,6 +1091,7 @@
             <div class="tile-actions">
               <a class="primary" href="https://github.com/ly-ccx/Peer-Agent/releases" target="_blank" rel="noreferrer" data-i18n="download.macos">macOS</a>
               <a class="secondary" href="https://github.com/ly-ccx/Peer-Agent/releases" target="_blank" rel="noreferrer" data-i18n="download.windows">Windows</a>
+              <a class="secondary" href="https://github.com/ly-ccx/Peer-Agent/releases" target="_blank" rel="noreferrer" data-i18n="download.linux">Linux</a>
             </div>
           </article>
           <article class="tile" id="download-cli">
@@ -1221,6 +1222,7 @@
               "No Desktop required. npm `@peer-agent/cli` or archive with peer + peer-credential-helper.",
             "download.macos": "macOS",
             "download.windows": "Windows",
+            "download.linux": "Linux",
             "download.npm": "npm install",
             "download.changelog": "Changelog →",
             "download.releases": "Releases →",
@@ -1319,6 +1321,7 @@
             "download.cliBody": "不必装 Desktop。npm `@peer-agent/cli`，或 peer + helper 压缩包。",
             "download.macos": "macOS",
             "download.windows": "Windows",
+            "download.linux": "Linux",
             "download.npm": "npm 安装",
             "download.changelog": "更新日志 →",
             "download.releases": "发布页 →",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "architecture:check": "node scripts/check-architecture-governance.mjs",
     "marketplace:build": "node marketplace/build-catalog.mjs",
     "marketplace:test": "node --test marketplace/*.test.mjs",
-    "changelog:test": "node --test scripts/build-changelog.test.mjs scripts/check-release-readiness.test.mjs scripts/package-cli-archive.test.mjs",
+    "changelog:test": "node --test scripts/build-changelog.test.mjs scripts/check-release-readiness.test.mjs scripts/package-cli-archive.test.mjs scripts/check-desktop-release-matrix.test.mjs",
     "package:cli": "node scripts/package-cli-archive.mjs",
     "version:check": "node scripts/check-version.mjs",
     "release:source-check": "node scripts/check-release-source.mjs",
@@ -29,6 +29,8 @@
     "dist": "pnpm build && pnpm --filter @peer-agent/desktop dist",
     "dist:mac": "pnpm build && pnpm --filter @peer-agent/desktop dist:mac",
     "dist:win": "pnpm build && pnpm --filter @peer-agent/desktop dist:win",
+    "pack:linux": "pnpm build && pnpm --filter @peer-agent/desktop pack:linux",
+    "dist:linux": "pnpm build && pnpm --filter @peer-agent/desktop dist:linux",
     "check": "pnpm architecture:check && pnpm typecheck && pnpm build:core",
     "dev:lab": "pnpm --filter @peer-agent/desktop run dev:lab"
   },

--- a/packages/npm-cli/README.md
+++ b/packages/npm-cli/README.md
@@ -46,6 +46,8 @@ Press **Y** or **Enter** to confirm, or **N** / **Esc** to dismiss. Restart `pee
 
 ## Supported platforms (today)
 
+This table is the **CLI installer** matrix only. Desktop Linux x64 ships separately on the same Release tag as `Peer-Agent-<ver>-x64.AppImage` / `.deb`.
+
 | Platform | Archive | Notes |
 |----------|---------|-------|
 | macOS arm64 | `peer-darwin-arm64.tar.gz` | First-class |

--- a/packages/npm-cli/lib/platform.mjs
+++ b/packages/npm-cli/lib/platform.mjs
@@ -1,8 +1,10 @@
 /**
  * Map Node process.platform / process.arch to the GitHub Release CLI archive name.
  *
- * First-class Release assets: peer-darwin-arm64.tar.gz, peer-linux-x64.tar.gz.
- * Other keys stay recognized so installers fail with a precise
+ * First-class CLI Release assets: peer-darwin-arm64.tar.gz, peer-linux-x64.tar.gz.
+ * Desktop Linux x64 is a separate Release track (AppImage / .deb + latest-linux.yml);
+ * this matrix only names CLI archives and must not be read as "Linux is CLI-only".
+ * Other CLI keys stay recognized so installers fail with a precise
  * "not yet published" message instead of inventing a wrong URL.
  */
 

--- a/release-notes/TEMPLATE.md
+++ b/release-notes/TEMPLATE.md
@@ -34,7 +34,8 @@ locale:zh-CN
 ## CLI（仅命令行）
 
 - 本版 GitHub Release 附带 CLI 归档（与 Desktop 同 tag / 同版本）。
-- 资产示例：`peer-darwin-arm64.tar.gz` / `peer-linux-x64.tar.gz`（内含 `peer` + `peer-credential-helper`，**必须同目录**）。
+- Desktop Linux x64 一等产物（若本版走正式打包轨道）：`Peer-Agent-<ver>-x64.AppImage` / `.deb` + `latest-linux.yml`（或 beta 等价清单）。
+- CLI 资产示例：`peer-darwin-arm64.tar.gz` / `peer-linux-x64.tar.gz`（内含 `peer` + `peer-credential-helper`，**必须同目录**）。
 - 安装方式：
   - **npm（有 `NPM_TOKEN` 且 publish 成功时）**：`npm i -g @peer-agent/cli`（或 `pnpm add -g @peer-agent/cli`），`postinstall` 自动拉本版归档。
   - **手动**：解压归档后将目录加入 `PATH`，执行 `peer --version` 校验，再运行 `peer`。
@@ -56,7 +57,8 @@ locale:en-US
 ## CLI (command-line only)
 
 - This GitHub Release ships a CLI archive under the same tag / version as Desktop.
-- Asset example: `peer-darwin-arm64.tar.gz` / `peer-linux-x64.tar.gz` (contains `peer` + `peer-credential-helper`; **must stay in the same directory**).
+- Desktop Linux x64 first-class assets (when this release ships the formal packaging track): `Peer-Agent-<ver>-x64.AppImage` / `.deb` plus `latest-linux.yml` (or the beta-channel equivalent).
+- CLI asset example: `peer-darwin-arm64.tar.gz` / `peer-linux-x64.tar.gz` (contains `peer` + `peer-credential-helper`; **must stay in the same directory**).
 - Install:
   - **npm** (when `NPM_TOKEN` is set and publish succeeds): `npm i -g @peer-agent/cli` (or `pnpm add -g @peer-agent/cli`); `postinstall` pulls this version's archive.
   - **Manual**: unpack, add the directory to `PATH`, run `peer --version`, then `peer`.

--- a/scripts/check-desktop-release-matrix.test.mjs
+++ b/scripts/check-desktop-release-matrix.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('electron-builder ships Linux Desktop AppImage + deb x64', () => {
+  const yml = readFileSync(join(root, 'apps/desktop/electron-builder.yml'), 'utf8');
+  const linuxStart = yml.indexOf('# ── Linux Desktop');
+  const linuxEnd = yml.indexOf('# ── 发布');
+  assert.ok(linuxStart >= 0 && linuxEnd > linuxStart, 'linux block markers missing');
+  const linuxBlock = yml.slice(linuxStart, linuxEnd);
+
+  assert.match(linuxBlock, /target:\s*AppImage/);
+  assert.match(linuxBlock, /target:\s*deb/);
+  assert.match(linuxBlock, /arch:\s*\[x64\]/);
+  assert.doesNotMatch(linuxBlock, /target:\s*dir/);
+  assert.match(yml, /latest-linux\.yml/);
+  assert.match(yml, /beta-linux\.yml/);
+  assert.match(yml, /artifactName: Peer-Agent-\$\{version\}-\$\{arch\}\.\$\{ext\}/);
+});
+
+test('release.yml builds and publishes Linux Desktop artifacts', () => {
+  const yml = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8');
+  assert.match(yml, /platform:\s*linux/);
+  assert.match(yml, /ebflags:\s*--linux --x64/);
+  assert.match(yml, /os:\s*ubuntu-latest/);
+  assert.match(yml, /\*\.AppImage/);
+  assert.match(yml, /\*\.deb/);
+  assert.match(yml, /latest-linux\.yml/);
+  assert.match(yml, /beta-linux\.yml/);
+  assert.match(yml, /libdbus-1-dev/);
+});
+
+test('README install section lists Linux Desktop AppImage and dist:linux', () => {
+  const en = readFileSync(join(root, 'README.md'), 'utf8');
+  const zh = readFileSync(join(root, 'README.zh-CN.md'), 'utf8');
+  for (const text of [en, zh]) {
+    assert.match(text, /Peer-Agent-<ver>-x64\.AppImage/);
+    assert.match(text, /pnpm dist:linux/);
+    assert.match(text, /pnpm pack:linux/);
+    assert.match(text, /latest-linux\.yml/);
+  }
+});
+
+test('package scripts expose pack:linux (dir) and dist:linux (AppImage/deb)', () => {
+  const rootPkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const desktopPkg = JSON.parse(readFileSync(join(root, 'apps/desktop/package.json'), 'utf8'));
+
+  assert.match(desktopPkg.scripts['pack:linux'], /--linux dir --x64/);
+  assert.match(desktopPkg.scripts['dist:linux'], /--linux --x64/);
+  assert.equal(rootPkg.scripts['pack:linux'], 'pnpm build && pnpm --filter @peer-agent/desktop pack:linux');
+  assert.equal(rootPkg.scripts['dist:linux'], 'pnpm build && pnpm --filter @peer-agent/desktop dist:linux');
+});

--- a/scripts/check-desktop-release-matrix.test.mjs
+++ b/scripts/check-desktop-release-matrix.test.mjs
@@ -20,6 +20,7 @@ test('electron-builder ships Linux Desktop AppImage + deb x64', () => {
   assert.match(yml, /latest-linux\.yml/);
   assert.match(yml, /beta-linux\.yml/);
   assert.match(yml, /artifactName: Peer-Agent-\$\{version\}-\$\{arch\}\.\$\{ext\}/);
+  assert.match(linuxBlock, /artifactName: Peer-Agent-\$\{version\}-x64\.\$\{ext\}/);
 });
 
 test('release.yml builds and publishes Linux Desktop artifacts', () => {

--- a/skills/release-process/SKILL.md
+++ b/skills/release-process/SKILL.md
@@ -2,7 +2,7 @@
 name: release-process
 description: Peer Agent 发版流程（版本戳、release notes、CHANGELOG、根 README 漂移检查、CLI 平台矩阵核对、GitHub Pages 文档站、打 tag 触发 CI）。
 whenToUse: 用户要求发版、打 beta/正式 tag、写 release notes、更新 CHANGELOG、检查/更新根 README、同步 docs 站点/Pages，或询问如何发布 Desktop/CLI。
-version: 0.1.4
+version: 0.1.5
 ---
 
 # Peer Agent 发布流程 Skill
@@ -158,7 +158,7 @@ python3 -m http.server 8777 --directory docs
 #### 每次发版至少扫这些字段
 
 1. **版本表述** — 是否仍写过时 early-development / 旧版本号；**且不得引用尚未发布的版本**：无对应 git tag 与 release note 的版本（如刚 stamp 的 `0.0.5-beta.1` 开发线）只能写作「开发中」，不得写成「当前 beta 通道」。可写当前系列（如 `0.0.4`）或指向 `VERSION` / Release。
-2. **安装路径与平台矩阵** — `@peer-agent/cli`、`peer`、Desktop 开发/打包命令是否与本轮一致；README 中的 CLI 平台表述必须与 `packages/npm-cli/lib/platform.mjs` 的 `supported` 矩阵一致（当前 `darwin-arm64` 与 `linux-x64` 一等支持，其余平台 `supported: false` 并在 postinstall 明确失败）。
+2. **安装路径与平台矩阵** — `@peer-agent/cli`、`peer`、Desktop 开发/打包命令是否与本轮一致；README 中的 **CLI** 平台表述必须与 `packages/npm-cli/lib/platform.mjs` 的 `supported` 矩阵一致（当前 `darwin-arm64` 与 `linux-x64` 一等支持，其余平台 `supported: false` 并在 postinstall 明确失败）。**Desktop** 平台矩阵是另一条轨道：macOS + Windows + Linux x64（AppImage / `.deb` + `latest-linux.yml`）为一等 Release 资产；不要把 CLI 矩阵读成「Linux 只有 CLI」。
 3. **入口面** — Desktop / TUI / CLI 是否仍与产品一致。
 4. **核心能力** — Agent / Plan / Goal / Quick Chat / Browser·Workbench / MCP / Skills 等用户可见能力是否过时或遗漏。
 5. **链接存活** — 相对链接与文档入口是否可达；禁止再把已迁出的架构文档写成代码仓内死链。
@@ -250,8 +250,9 @@ CI（`release.yml`）会：
 
 - 在任何构建/发布前运行 `version:check` 与 `release:source-check`
 - 从 tag 解析版本/通道
-- matrix 构建 Desktop（mac/win）
+- matrix 构建 Desktop（mac / win / linux x64 AppImage + `.deb`）
 - 组装 CLI 归档（含 `peer` + `peer-credential-helper`；当前矩阵 `darwin-arm64` + `linux-x64`，脚本 `scripts/package-cli-archive.mjs`）
+- 上传更新清单（`latest-mac.yml` / `latest.yml` / `latest-linux.yml`，或 beta 等价文件）
 - 创建/更新 GitHub Release，上传产物与更新清单
 
 **不要**在本地绕过 workflow 手工伪造“已发布”状态，除非用户明确要求且你说明风险。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

#17 已把 Linux `dir` unpacked 留在 `electron-builder.yml` 里，那是沙箱 / keep-alive 冒烟用的。按后续要求，这条 PR 把 **Linux Desktop x64** 提升为独立于 CLI 的正式发布轨道，不改 keep-alive UI，也不 stamp 版本 / 不打 tag。

基线：`0.0.12`。

## 产物

本地已跑通 `pnpm --filter @peer-agent/desktop dist:linux`，实际产出：

| 资产 | 作用 |
| --- | --- |
| `Peer-Agent-<ver>-x64.AppImage` | 首选便携包；`electron-updater` 主路径 |
| `Peer-Agent-<ver>-x64.deb` | apt 安装便利；应用内自动更新仍以 AppImage 为准 |
| `latest-linux.yml` | Linux 更新通道清单（beta tag 对应 `beta-linux.yml`） |

文件名强制 `x64`（不用 Linux 默认的 `x86_64` / `amd64`），与 mac/win 命名纪律一致。`latest-linux.yml` 的 `path` 指向 AppImage。

`pnpm pack:linux` 仍显式打 `--linux dir`，供 CI / 沙箱 unpacked 冒烟，**不**作为 Release 资产。

## CI

`.github/workflows/release.yml` Desktop `build` matrix 增加 `ubuntu-latest`：

- 安装 `libdbus-1-dev` / `pkg-config` / `fakeroot` / `dpkg`
- 构建 Rust `peer-credential-helper`
- `electron-builder --linux --x64 --publish never`
- 上传 AppImage / deb / yml
- 汇总 release job **缺 AppImage、.deb 或 linux 更新清单即失败**

## 安装（用户）

```bash
# AppImage（推荐）
chmod +x Peer-Agent-<ver>-x64.AppImage
./Peer-Agent-<ver>-x64.AppImage

# 或 .deb
sudo dpkg -i Peer-Agent-<ver>-x64.deb
```

本地构建：

```bash
pnpm pack:linux   # unpacked dir
pnpm dist:linux   # AppImage + .deb
```

`.deb` 安装到 `/opt/Peer Agent/`，菜单项为 `com.peeragent.desktop`，`StartupWMClass=com.peeragent.desktop`。Depends 含 `libsecret-1-0`（凭证库）。

## 阶段一缺口（写进 README / docs）

- **未签名**（与 mac ad-hoc 同级）
- **仅 x64**；linux-arm64 Desktop 后续
- 应用内自动更新只支持 **AppImage**
- Ubuntu 22+/24+ 跑 AppImage 可能需要 `libfuse2`
- Wayland 窗口起不来时：X11 或 `ELECTRON_OZONE_PLATFORM_HINT=auto`

## 架构影响

C 级偏发布面：只扩 electron-builder 目标、Release 矩阵与文档。未改 Capability / Permission / Evidence / System Context，也未动 renderer 能力路径。updater 仍只在 `darwin` 走自管 dmg；Linux 与 Windows 共用 `electron-updater.downloadUpdate()`。

未写 Peer-Knowledge（知识仓未挂载；产品仓 README / docs / release playbook 已对齐）。

## 验证

- `scripts/check-desktop-release-matrix.test.mjs` + updater / CLI platform 单测通过
- 本机 `dist:linux` 产出 AppImage + deb + `latest-linux.yml`，`verify:packaged` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a64e9dcf-236c-4236-b658-2cb9ecc528fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a64e9dcf-236c-4236-b658-2cb9ecc528fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

